### PR TITLE
fix: ensure at least one event always renders in month grid rows

### DIFF
--- a/src/Calendar/components/DayGrid/utils/useTotalEventsToShow.js
+++ b/src/Calendar/components/DayGrid/utils/useTotalEventsToShow.js
@@ -51,7 +51,7 @@ const useTotalEventsToShow = () => {
   useEffect(() => {
     if (eventHeight > 0) {
       setTotalEventsToShow(
-        Math.floor((rowHeight - eventWrapperMargin) / eventHeight) - 1
+        Math.max(1, Math.floor((rowHeight - eventWrapperMargin) / eventHeight) - 1)
       );
     }
   }, [rowHeight, eventHeight, eventWrapperMargin]);


### PR DESCRIPTION
## Description

<!-- Explain what change is being made and why it was made. -->

The month grid in `CalendarMonth` computes how many events fit per row using
`Math.floor((rowHeight - eventWrapperMargin) / eventHeight) - 1`. On short rows
(e.g. inside a height-constrained drawer), this evaluates to `0` or negative,
which causes Acuity to set `opacity: 0` on the event wrapper and skip rendering
events entirely — so date-specific provider hour overrides become invisible.

Wrap the result in `Math.max(1, …)` so at least one event is always shown when
`eventHeight > 0`. Additional events beyond the first still overflow into the
`+ N more` bucket as before.

**Note:** This branch also includes prior commits already on `main` (drag-and-drop
fixes, `react-draggable` upgrade, dynamic event colors, etc.). If this PR should
be scoped to only the min-events fix, cherry-pick `99512eb` onto a fresh branch
from `main` instead.

## What type of PR is this?

<!-- Check all applicable. -->

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Test Plan

<!-- Write a detailed description of how you tested your changes. If applicable, use GIFs, video recordings, and images for support. -->

1. Open a view that renders `CalendarMonth` inside a height-constrained container
   (e.g. provider hours drawer with `height: 60vh`).
2. Set a date-specific hour override for a day without a regular weekly schedule.
3. **Before fix:** the event title is invisible or the cell appears empty.
4. **After fix:** the event title (e.g. `9:00 AM - 5:00 PM`) renders in the cell.
5. Resize the browser to a smaller viewport and confirm events remain visible.
6. If multiple events exist on one day, confirm overflow shows `+ N more` as expected.

## Author Reminders

- [ ] I have added or updated **tests** that cover my code changes.
- [ ] I have added or updated **documentation** related to this PR.
- [ ] I have added or updated **logging** wherever necessary.
- [ ] I have made UI changes and added **screenshots** to help identify them.
- [ ] I have added, removed, or updated **dependencies** following the [Handling Dependencies Guideline](https://github.com/quiltedhealth/ehr?tab=readme-ov-file#handling-dependencies).

## Summary by Sourcery

Bug Fixes:
- Prevent month grid rows from hiding all events when the computed per-row capacity is zero or negative by enforcing a minimum of one visible event.